### PR TITLE
Update astro_dmx to 2.10.2

### DIFF
--- a/packages/astro_dmx/PKGBUILD
+++ b/packages/astro_dmx/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: Mattia Procopio (astro.matto)  <matto.astro at gmail dot com>
 pkgname=astro_dmx
-pkgver=2.9.7
+pkgver=2.10.1
+[ "$CARCH" = "aarch64" ] && pkgver=2.10.2
 pkgrel=1
 pkgdesc="Video capturing software for astronomy"
 arch=(x86_64 aarch64)
@@ -9,14 +10,14 @@ license=('LGPLv2')
 depends=(gtk3 libsm)
 source=("astro_dmx.tar.gz::https://www.astrodmx-capture.org.uk/downloads/astrodmx/current/linux-x86_64/astrodmx-capture_${pkgver}_x86-64-manual.tar.gz")
 [ "$CARCH" = "aarch64" ] && source=("astro_dmx.tar.gz::https://www.astrodmx-capture.org.uk/downloads/astrodmx/current/linux-arm/astrodmx-glibc-2.28_${pkgver}_manual-aarch64.tar.gz")
-sha256sums=('60aae9562aaff2a68fb37997effadf0627a3eeab7a3c0e8cd0499157044e9ba9')
-[ "$CARCH" = "aarch64" ] && sha256sums=('60aae9562aaff2a68fb37997effadf0627a3eeab7a3c0e8cd0499157044e9ba9')
+sha256sums=('858550756dce9ba79f713666b5ef2c758249f0cd0106443046e9bbf9cdbb4b19')
+[ "$CARCH" = "aarch64" ] && sha256sums=('16f45761d53935bd5b4fed323c507d22326c7138cc2381c6555dc7022ed24f9f')
 _app_folder=AstroDMx-${pkgver}-manual
 [ "$CARCH" = "aarch64" ] && _app_folder=R-Linux-aarch64-2.28
 
 
 build() {
-  tar xvfz astro_dmx.tar.gz -C "$srcdir"
+    tar xvfz astro_dmx.tar.gz -C "$srcdir"
 }
 
 package() {


### PR DESCRIPTION
Version 2.10(.1) of AstroDMx Capture was released at the end of September ([changelog](https://www.astrodmx-capture.org.uk/astrodmx-capture-changelog/)). Patch 2.10.2 for ARM was released shortly thereafter to address a Raspberry Pi-specific issue.

This PR updates the PKGBUILD to the latest version available for both possible architectures.